### PR TITLE
Migrate to parent POM version 0.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.palladiosimulator</groupId>
         <artifactId>eclipse-parent-updatesite</artifactId>
-        <version>0.8.9</version>
+        <version>0.9.0</version>
     </parent>
 
     <groupId>org.palladiosimulator.somox</groupId>


### PR DESCRIPTION
- Migrate from parent POM version 0.8.9 to the new parent POM version 0.9.0
- Locally verified build success